### PR TITLE
Fix chart path handling

### DIFF
--- a/report_docx.py
+++ b/report_docx.py
@@ -4,6 +4,25 @@ from docx.shared import Inches
 import os
 
 def generate_docx_report(session_id, hw_df, sw_df, chart_paths):
+    """Generate a detailed DOCX report.
+
+    Parameters
+    ----------
+    session_id : str
+        Unique identifier for the current assessment session.
+    hw_df : pandas.DataFrame
+        Hardware dataframe to summarize.
+    sw_df : pandas.DataFrame
+        Software dataframe to summarize.
+    chart_paths : dict
+        Dictionary of chart names to file paths returned by
+        :func:`visualization.generate_charts`.
+
+    Returns
+    -------
+    str or None
+        Path to the generated DOCX file or ``None`` if generation failed.
+    """
     try:
         output_path = os.path.join("temp_sessions", session_id, "IT_Current_Status_Assessment_Report.docx")
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
@@ -41,7 +60,7 @@ def generate_docx_report(session_id, hw_df, sw_df, chart_paths):
             document.add_paragraph("No software data available.")
 
         document.add_heading('Charts & Visualizations', level=1)
-        for chart_path in chart_paths:
+        for chart_path in chart_paths.values():
             if os.path.exists(chart_path):
                 document.add_picture(chart_path, width=Inches(5.5))
             else:

--- a/report_pptx.py
+++ b/report_pptx.py
@@ -6,6 +6,25 @@ from pptx.enum.shapes import MSO_SHAPE
 from pptx.dml.color import RGBColor
 
 def generate_pptx_report(session_id, hw_df, sw_df, chart_paths):
+    """Generate an executive summary PPTX report.
+
+    Parameters
+    ----------
+    session_id : str
+        Unique identifier for the current assessment session.
+    hw_df : pandas.DataFrame
+        Hardware dataframe to summarize.
+    sw_df : pandas.DataFrame
+        Software dataframe to summarize.
+    chart_paths : dict
+        Dictionary of chart names to file paths returned by
+        :func:`visualization.generate_charts`.
+
+    Returns
+    -------
+    str or None
+        Path to the generated PPTX file or ``None`` if generation failed.
+    """
     try:
         output_dir = os.path.join("temp_sessions", session_id)
         os.makedirs(output_dir, exist_ok=True)
@@ -34,7 +53,7 @@ def generate_pptx_report(session_id, hw_df, sw_df, chart_paths):
         slide.placeholders[1].text = sw_summary
 
         # Charts
-        for path in chart_paths:
+        for path in chart_paths.values():
             if os.path.exists(path):
                 slide = prs.slides.add_slide(blank_layout)
                 left = Inches(1)

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pandas as pd
+import zipfile
+import matplotlib
+
+sys.path.insert(0, os.getcwd())
+
+from visualization import generate_charts
+from report_docx import generate_docx_report
+from report_pptx import generate_pptx_report
+
+
+def test_reports_include_charts(tmp_path, monkeypatch):
+    matplotlib.use("Agg")
+    # work in tmp directory to avoid polluting repo
+    monkeypatch.chdir(tmp_path)
+
+    session_id = "test_session"
+    hw_df = pd.DataFrame({"Tier": ["1"], "Status": ["Active"]})
+    sw_df = pd.DataFrame({"Tier": ["1"], "Status": ["Active"]})
+
+    session_folder = os.path.join("temp_sessions", session_id)
+    charts = generate_charts(hw_df, sw_df, session_folder)
+
+    docx_path = generate_docx_report(session_id, hw_df, sw_df, charts)
+    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, charts)
+
+    with zipfile.ZipFile(docx_path) as zf:
+        assert any(name.startswith("word/media/") for name in zf.namelist())
+
+    with zipfile.ZipFile(pptx_path) as zf:
+        assert any(name.startswith("ppt/media/") for name in zf.namelist())


### PR DESCRIPTION
## Summary
- iterate over `chart_paths.values()` so the real image paths are used
- document that `chart_paths` comes from `visualization.generate_charts`
- add regression test checking that charts are embedded in generated reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464f4a1d98832698b087badf2f5d5a