### PR TITLE
Handle None inputs in report generation

### DIFF
--- a/report_docx.py
+++ b/report_docx.py
@@ -34,7 +34,7 @@ def generate_docx_report(session_id, hw_df, sw_df, chart_paths):
         document.add_paragraph(session_id)
 
         document.add_heading('Hardware Summary', level=1)
-        if not hw_df.empty:
+        if hw_df is not None and not hw_df.empty:
             table = document.add_table(rows=1, cols=len(hw_df.columns))
             hdr_cells = table.rows[0].cells
             for i, col in enumerate(hw_df.columns):
@@ -47,7 +47,7 @@ def generate_docx_report(session_id, hw_df, sw_df, chart_paths):
             document.add_paragraph("No hardware data available.")
 
         document.add_heading('Software Summary', level=1)
-        if not sw_df.empty:
+        if sw_df is not None and not sw_df.empty:
             table = document.add_table(rows=1, cols=len(sw_df.columns))
             hdr_cells = table.rows[0].cells
             for i, col in enumerate(sw_df.columns):

--- a/report_pptx.py
+++ b/report_pptx.py
@@ -43,13 +43,27 @@ def generate_pptx_report(session_id, hw_df, sw_df, chart_paths):
         # HW Summary
         slide = prs.slides.add_slide(content_layout)
         slide.shapes.title.text = "Hardware Summary"
-        hw_summary = f"Total HW Devices: {len(hw_df)}\nTier Distribution:\n{hw_df['Tier'].value_counts().to_string()}" if 'Tier' in hw_df.columns else "No tier data."
+        if hw_df is not None and not hw_df.empty:
+            if 'Tier' in hw_df.columns:
+                tier_text = hw_df['Tier'].value_counts().to_string()
+            else:
+                tier_text = "No tier data."
+            hw_summary = f"Total HW Devices: {len(hw_df)}\nTier Distribution:\n{tier_text}"
+        else:
+            hw_summary = "No hardware data available."
         slide.placeholders[1].text = hw_summary
 
         # SW Summary
         slide = prs.slides.add_slide(content_layout)
         slide.shapes.title.text = "Software Summary"
-        sw_summary = f"Total SW Packages: {len(sw_df)}\nTier Distribution:\n{sw_df['Tier'].value_counts().to_string()}" if 'Tier' in sw_df.columns else "No tier data."
+        if sw_df is not None and not sw_df.empty:
+            if 'Tier' in sw_df.columns:
+                tier_text = sw_df['Tier'].value_counts().to_string()
+            else:
+                tier_text = "No tier data."
+            sw_summary = f"Total SW Packages: {len(sw_df)}\nTier Distribution:\n{tier_text}"
+        else:
+            sw_summary = "No software data available."
         slide.placeholders[1].text = sw_summary
 
         # Charts

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -31,3 +31,48 @@ def test_reports_include_charts(tmp_path, monkeypatch):
 
     with zipfile.ZipFile(pptx_path) as zf:
         assert any(name.startswith("ppt/media/") for name in zf.namelist())
+
+
+def test_reports_hardware_only(tmp_path, monkeypatch):
+    matplotlib.use("Agg")
+    monkeypatch.chdir(tmp_path)
+
+    session_id = "hw_only"
+    hw_df = pd.DataFrame({"Tier": ["1"], "Status": ["Active"]})
+    sw_df = None
+
+    docx_path = generate_docx_report(session_id, hw_df, sw_df, {})
+    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, {})
+
+    assert os.path.exists(docx_path)
+    assert os.path.exists(pptx_path)
+
+
+def test_reports_software_only(tmp_path, monkeypatch):
+    matplotlib.use("Agg")
+    monkeypatch.chdir(tmp_path)
+
+    session_id = "sw_only"
+    hw_df = None
+    sw_df = pd.DataFrame({"Tier": ["1"], "Status": ["Active"]})
+
+    docx_path = generate_docx_report(session_id, hw_df, sw_df, {})
+    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, {})
+
+    assert os.path.exists(docx_path)
+    assert os.path.exists(pptx_path)
+
+
+def test_reports_no_data(tmp_path, monkeypatch):
+    matplotlib.use("Agg")
+    monkeypatch.chdir(tmp_path)
+
+    session_id = "no_data"
+    hw_df = None
+    sw_df = None
+
+    docx_path = generate_docx_report(session_id, hw_df, sw_df, {})
+    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, {})
+
+    assert os.path.exists(docx_path)
+    assert os.path.exists(pptx_path)


### PR DESCRIPTION
## Summary
- avoid AttributeErrors when hw/sw dataframes are `None`
- update PPTX summary generation to check for data presence
- test DOCX and PPTX generation when hardware, software or both are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684652a3b9508326afb14954a8511d01