### PR TITLE
Add remote file download support

### DIFF
--- a/generate_assessment.py
+++ b/generate_assessment.py
@@ -6,6 +6,15 @@ from visualization import generate_visual_charts
 from report_docx import generate_docx_report
 from report_pptx import generate_pptx_report
 
+"""Utilities to generate an IT assessment report.
+
+The :func:`generate_assessment` function downloads the provided Excel files
+into a per-session directory. If the ``file_url`` field of an entry starts with
+``http://`` or ``https://`` the file is fetched using :func:`requests.get`.
+Otherwise ``file_url`` is treated as a local path and the file is copied
+directly. The downloaded files are then processed to produce reports and charts.
+"""
+
 def generate_assessment(session_id, email, goal, files, next_action_webhook):
     session_path = os.path.join("temp_sessions", session_id)
     os.makedirs(session_path, exist_ok=True)
@@ -19,9 +28,15 @@ def generate_assessment(session_id, email, goal, files, next_action_webhook):
         file_name = file['file_name']
         local_path = os.path.join(session_path, file_name)
 
-        # Simulate download (actual logic may involve URL fetching)
-        with open(local_path, "wb") as f:
-            f.write(open(file_url, "rb").read())
+        # Download remote files or copy local ones
+        if file_url.startswith(("http://", "https://")):
+            response = requests.get(file_url)
+            response.raise_for_status()
+            with open(local_path, "wb") as f:
+                f.write(response.content)
+        else:
+            with open(file_url, "rb") as src, open(local_path, "wb") as dst:
+                dst.write(src.read())
 
         if "hardware" in ftype or "hw" in file_name.lower():
             hw_file_path = local_path

--- a/tests/test_generate_assessment.py
+++ b/tests/test_generate_assessment.py
@@ -1,0 +1,80 @@
+import os
+import sys
+from io import BytesIO
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.getcwd())
+
+import generate_assessment
+
+
+class DummyResponse:
+    def __init__(self, content: bytes):
+        self.content = content
+        self.status_code = 200
+    def raise_for_status(self):
+        pass
+
+
+def setup_common_monkeypatch(monkeypatch, tmp_path):
+    # Patch heavy report/chart generation functions
+    monkeypatch.setattr(generate_assessment, "generate_visual_charts", lambda *a, **k: {})
+    monkeypatch.setattr(generate_assessment, "generate_docx_report", lambda *a, **k: "docx")
+    monkeypatch.setattr(generate_assessment, "generate_pptx_report", lambda *a, **k: "pptx")
+    
+    class PostResp:
+        status_code = 200
+    monkeypatch.setattr(generate_assessment.requests, "post", lambda *a, **k: PostResp())
+
+
+def test_local_file_copy(tmp_path, monkeypatch):
+    setup_common_monkeypatch(monkeypatch, tmp_path)
+
+    df = pd.DataFrame({"a": [1, 2]})
+    local_src = tmp_path / "hw.xlsx"
+    df.to_excel(local_src, index=False)
+
+    files = [{
+        "type": "hardware",
+        "file_url": str(local_src),
+        "file_name": "hw.xlsx",
+    }]
+
+    session_id = "local"
+    generate_assessment.generate_assessment(session_id, "", "", files, "http://example.com")
+
+    session_file = os.path.join("temp_sessions", session_id, "hw.xlsx")
+    assert os.path.exists(session_file)
+    df_read = pd.read_excel(session_file)
+    assert df_read.equals(df)
+
+
+def test_remote_file_download(tmp_path, monkeypatch):
+    setup_common_monkeypatch(monkeypatch, tmp_path)
+
+    df = pd.DataFrame({"b": [3, 4]})
+    bio = BytesIO()
+    df.to_excel(bio, index=False)
+    bio.seek(0)
+
+    monkeypatch.setattr(
+        generate_assessment.requests,
+        "get",
+        lambda url: DummyResponse(bio.getvalue()),
+    )
+
+    files = [{
+        "type": "hardware",
+        "file_url": "http://example.com/hw.xlsx",
+        "file_name": "hw.xlsx",
+    }]
+
+    session_id = "remote"
+    generate_assessment.generate_assessment(session_id, "", "", files, "http://example.com")
+
+    session_file = os.path.join("temp_sessions", session_id, "hw.xlsx")
+    assert os.path.exists(session_file)
+    df_read = pd.read_excel(session_file)
+    assert df_read.equals(df)
+


### PR DESCRIPTION
## Summary
- describe remote download vs local copy behavior in `generate_assessment`
- download files with `requests.get` when URLs are provided
- add tests for local and remote file inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684657920380832685fd7e3da3fdca83