### PR TITLE
Improve chart generation

### DIFF
--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -41,11 +41,17 @@ def test_reports_hardware_only(tmp_path, monkeypatch):
     hw_df = pd.DataFrame({"Tier": ["1"], "Status": ["Active"]})
     sw_df = None
 
-    docx_path = generate_docx_report(session_id, hw_df, sw_df, {})
-    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, {})
+    session_folder = os.path.join("temp_sessions", session_id)
+    charts = generate_charts(hw_df, sw_df, session_folder)
 
-    assert os.path.exists(docx_path)
-    assert os.path.exists(pptx_path)
+    docx_path = generate_docx_report(session_id, hw_df, sw_df, charts)
+    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, charts)
+
+    with zipfile.ZipFile(docx_path) as zf:
+        assert any(name.startswith("word/media/") for name in zf.namelist())
+
+    with zipfile.ZipFile(pptx_path) as zf:
+        assert any(name.startswith("ppt/media/") for name in zf.namelist())
 
 
 def test_reports_software_only(tmp_path, monkeypatch):
@@ -56,11 +62,17 @@ def test_reports_software_only(tmp_path, monkeypatch):
     hw_df = None
     sw_df = pd.DataFrame({"Tier": ["1"], "Status": ["Active"]})
 
-    docx_path = generate_docx_report(session_id, hw_df, sw_df, {})
-    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, {})
+    session_folder = os.path.join("temp_sessions", session_id)
+    charts = generate_charts(hw_df, sw_df, session_folder)
 
-    assert os.path.exists(docx_path)
-    assert os.path.exists(pptx_path)
+    docx_path = generate_docx_report(session_id, hw_df, sw_df, charts)
+    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, charts)
+
+    with zipfile.ZipFile(docx_path) as zf:
+        assert any(name.startswith("word/media/") for name in zf.namelist())
+
+    with zipfile.ZipFile(pptx_path) as zf:
+        assert any(name.startswith("ppt/media/") for name in zf.namelist())
 
 
 def test_reports_no_data(tmp_path, monkeypatch):
@@ -71,8 +83,11 @@ def test_reports_no_data(tmp_path, monkeypatch):
     hw_df = None
     sw_df = None
 
-    docx_path = generate_docx_report(session_id, hw_df, sw_df, {})
-    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, {})
+    session_folder = os.path.join("temp_sessions", session_id)
+    charts = generate_charts(hw_df, sw_df, session_folder)
+
+    docx_path = generate_docx_report(session_id, hw_df, sw_df, charts)
+    pptx_path = generate_pptx_report(session_id, hw_df, sw_df, charts)
 
     assert os.path.exists(docx_path)
     assert os.path.exists(pptx_path)

--- a/visualization.py
+++ b/visualization.py
@@ -14,12 +14,19 @@ def generate_charts(hw_df, sw_df, session_folder):
         plt.close()
         return chart_path
 
-    charts = {
-        "hw_tier_chart": pie_chart(hw_df, "Tier", "Hardware Tier Distribution", "hw_tier_chart.png"),
-        "hw_status_chart": pie_chart(hw_df, "Status", "Hardware Status", "hw_status_chart.png"),
-        "sw_tier_chart": pie_chart(sw_df, "Tier", "Software Tier Distribution", "sw_tier_chart.png"),
-        "sw_status_chart": pie_chart(sw_df, "Status", "Software Status", "sw_status_chart.png")
-    }
+    charts = {}
+
+    if hw_df is not None and not hw_df.empty:
+        if "Tier" in hw_df:
+            charts["hw_tier_chart"] = pie_chart(hw_df, "Tier", "Hardware Tier Distribution", "hw_tier_chart.png")
+        if "Status" in hw_df:
+            charts["hw_status_chart"] = pie_chart(hw_df, "Status", "Hardware Status", "hw_status_chart.png")
+
+    if sw_df is not None and not sw_df.empty:
+        if "Tier" in sw_df:
+            charts["sw_tier_chart"] = pie_chart(sw_df, "Tier", "Software Tier Distribution", "sw_tier_chart.png")
+        if "Status" in sw_df:
+            charts["sw_status_chart"] = pie_chart(sw_df, "Status", "Software Status", "sw_status_chart.png")
 
     return charts
 


### PR DESCRIPTION
## Summary
- avoid errors when `hw_df` or `sw_df` is missing
- return only generated chart paths
- update docx/pptx tests to call `generate_charts`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684658756cec83269b5a6af08314aa19