### PR TITLE
Serve assessment files via Flask

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import os
 import json
 import traceback
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory
 from generate_assessment import process_assessment
 
 app = Flask(__name__)
@@ -31,6 +31,12 @@ def start_assessment():
         print("❌ Error in /start_assessment:", str(e), flush=True)
         traceback.print_exc()
         return jsonify({"error": str(e)}), 500
+
+
+@app.route("/files/<path:filename>", methods=["GET"])
+def serve_file(filename):
+    """Serve generated files from the ``temp_sessions`` folder."""
+    return send_from_directory("temp_sessions", filename, as_attachment=True)
 
 @app.route("/", methods=["GET"])
 def index():

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.getcwd())
+
+from app import app
+import generate_assessment
+
+
+def setup_api_monkeypatch(monkeypatch):
+    def write_placeholder(path):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(b"x")
+        return path
+
+    monkeypatch.setattr(generate_assessment, "generate_visual_charts", lambda *a, **k: {})
+    monkeypatch.setattr(
+        generate_assessment,
+        "generate_docx_report",
+        lambda session_id, *a, **k: write_placeholder(os.path.join("temp_sessions", session_id, "IT_Current_Status_Assessment_Report.docx")),
+    )
+    monkeypatch.setattr(
+        generate_assessment,
+        "generate_pptx_report",
+        lambda session_id, *a, **k: write_placeholder(os.path.join("temp_sessions", session_id, "IT_Current_Status_Executive_Report.pptx")),
+    )
+
+    class DummyResp:
+        status_code = 200
+    monkeypatch.setattr(generate_assessment.requests, "post", lambda *a, **k: DummyResp())
+
+
+def test_start_assessment_downloadable_urls(tmp_path, monkeypatch):
+    setup_api_monkeypatch(monkeypatch)
+
+    hw_df = pd.DataFrame({"a": [1]})
+    sw_df = pd.DataFrame({"b": [2]})
+    hw_path = tmp_path / "hw.xlsx"
+    sw_path = tmp_path / "sw.xlsx"
+    hw_df.to_excel(hw_path, index=False)
+    sw_df.to_excel(sw_path, index=False)
+
+    files = [
+        {"type": "hardware", "file_url": str(hw_path), "file_name": "hw.xlsx"},
+        {"type": "software", "file_url": str(sw_path), "file_name": "sw.xlsx"},
+    ]
+
+    client = app.test_client()
+    resp = client.post(
+        "/start_assessment",
+        json={
+            "session_id": "sess",
+            "email": "user@example.com",
+            "goal": "goal",
+            "files": files,
+            "next_action_webhook": "http://example.com",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    urls = [data["result"][f"file_{i}_url"] for i in range(1, 5)]
+    for url in urls:
+        r = client.get(url)
+        assert r.status_code == 200


### PR DESCRIPTION
## Summary
- expose generated output through `/files/<filename>`
- return file URLs from `generate_assessment`
- integration test confirms assessment API returns downloadable files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846596cc6e083268a48f7ff78745504